### PR TITLE
omit confusing text about Java's naming convention

### DIFF
--- a/style/naming-conventions.md
+++ b/style/naming-conventions.md
@@ -249,7 +249,7 @@ easily transform even the simplest code into symbolic soup.
 
 Constant names should be in upper camel case. That is, if the member is
 final, immutable and it belongs to a package object or an object,
-it may be considered a constant (similar to Java's `static final` members):
+it may be considered a constant:
 
     object Container {
       val MyConstant = ...


### PR DESCRIPTION
Java does not follow upper camel case for constants naming convention, according to the [Code Conventions for the Java™ Programming Language](http://www.oracle.com/technetwork/java/codeconventions-135099.html):

> The names of variables declared class constants and of ANSI constants should be all uppercase with words separated by underscores ("_")
